### PR TITLE
Removing glib headers from cellular_hal.h

### DIFF
--- a/include/cellular_hal.h
+++ b/include/cellular_hal.h
@@ -45,13 +45,7 @@
 #include <pthread.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-#include <glib.h>
-#include <glib/gprintf.h>
-#include <gio/gio.h>
-#include <glib-unix.h>
-#ifndef CELLULAR_MGR_LITE
-#include <libqmi-glib.h>
-#endif
+
 /**********************************************************************
                 STRUCTURE AND CONSTANT DEFINITIONS
 **********************************************************************/


### PR DESCRIPTION
Removing the additional glib headers from the cellular_hal.h